### PR TITLE
Fix Speaker registration button's visibility in mobile view

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -192,3 +192,13 @@
 #myBtn:hover {
     background-color: transparent;
 }
+@media all and (max-width: 767px) {
+  .hero-slider .btn-hollow {
+    display: inline-block;
+    margin-left: 0;
+  }
+  .hero-slider .btn{
+    margin-bottom: 15px;
+    margin-right: 8px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
                         <div class="row">
                             <div class="col-md-offset-1 col-sm-10 col-sm-offset-1 text-center col-md-10">
                                 <img alt="logo" class="logo" src="img/OpenTechSummit.png">
-                                <span class="uppercase text-white sub-heading-font ">OpenTechSummit Sri Lanka</span> <h1 class="large-h1 text-white">
+                                    <span class="uppercase text-white sub-heading-font ">Sri Lanka</span> <h1 class="large-h1 text-white">
                                  <!--   <span>The future is FOSS!</span><br> -->
                                 <span>Asia's Premier Developer Event<br>
                                 6 January, 2020<br>


### PR DESCRIPTION
# Purpose 
The purpose of this PR is to fix issue #3 

# Approach
- Add custom CSS rule for the registration button, to be visible in mobile view.
- Remove Opentechsummit Sri Lanka on the heading and replace Sri Lanka.

# Preview 
https://kumuditha-udayanga.github.io/srilanka.opentech.asia/

# Screenshot
- Before
<img width="421" alt="Screenshot 2019-12-22 at 00 13 56" src="https://user-images.githubusercontent.com/27630091/71312371-f898c800-244f-11ea-859a-a028ba2a3139.png">

- After
<img width="408" alt="Screenshot 2019-12-22 at 00 14 59" src="https://user-images.githubusercontent.com/27630091/71312379-1bc37780-2450-11ea-83c1-a60fbb53a365.png">

