### PR TITLE
Fix venue image & Fix wrong university name

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -202,3 +202,26 @@
     margin-right: 8px;
   }
 }
+
+.p-0 {
+  padding: 0;
+}
+
+@media all and (max-width: 767px) {
+  #venue .image-with-text {
+    padding-top: 0;
+  }
+
+  #venue .background-image-holder {
+    position: relative;
+    height: 400px;
+  }
+
+  #venue .side-image {
+    position: relative;
+  }
+
+  .image-with-text .vertical-align {
+    padding-top: 30px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -943,16 +943,16 @@
             </div>
         </section>
 
-			<a id="venue" class="in-page-link"></a>
-			<section class="image-with-text background-dark preserve-3d">
-				<div class="go-left side-image col-sm-4 col-md-6">
+        <section id="venue" class="p-0">
+			<div class="image-with-text background-dark preserve-3d">
+				<div class="go-left side-image col-sm-6 col-md-6">
 					<div class="background-image-holder">
 						<img class="background-image" alt="query-server" src="img/venue.jpg">
 					</div>
 				</div>
 				<div class="container vertical-align">
 					<div class="row">
-						<div class="col-md-5 col-md-offset-7 col-sm-7 col-sm-offset-5">
+						<div class="col-md-5 col-md-offset-7 col-sm-6 col-sm-offset-6">
 							<h1 class="text-white">Summit Venue - University of Moratuwa</h1>
 							<p class="lead text-white">
 								The <a target="default" href="https://www.mrt.ac.lk/">University of Moratuwa</a> is hosting the OpenTechSummit as a partner of the event.<br>
@@ -960,15 +960,15 @@
 						</div>
 					</div>
 				</div>
-			</section>
-
+			</div>
+        </section>
         <a id="map" class="in-page-link"></a>
         <section class="contact-tweets">
             <div class="container vertical-align">
                 <div class="row">
                     <div class="col-md-5 col-sm-6">
                         <span class="text-white">
-                            <h1 class="text-white"><a target="default" href="https://www.mrt.ac.lk/">Muratowa University</a> is the event location for the OpenTechSummit.</h1>
+                            <h1 class="text-white"><a target="default" href="https://www.mrt.ac.lk/">Moratowa University</a> is the event location for the OpenTechSummit.</h1>
                             <h1 class="text-white">Address:<br>
                             Bandaranayake Mawatha<br>
                             Moratuwa 10400<br>


### PR DESCRIPTION
## Purpose
The purpose is to fix #7 & display venue image in the mobile view (#1 ).

## Approach
- Replace the university name with correct name; "Moratuwa"
- Overriding existing CSS rules to display venue image in mobile view
- Fix venue image alignment in tablet view 

## Preview Link 
http://jayasanka.me/srilanka.opentech.asia/

## Screenshots
![Screenshot 2019-12-30 at 18 40 21](https://user-images.githubusercontent.com/33048395/71583304-d976f600-2b33-11ea-89be-607086cb9c4c.jpg)
![Screenshot 2019-12-30 at 18 40 58](https://user-images.githubusercontent.com/33048395/71583322-edbaf300-2b33-11ea-9498-00897246a5bd.jpg)


